### PR TITLE
C50-565 When BOT Executor drops a request it should be cleared by Bot…

### DIFF
--- a/server/app/services/botService.js
+++ b/server/app/services/botService.js
@@ -418,7 +418,8 @@ botService.executeBots = function executeBots(botsId, reqBody, userName, executi
                             var error = new Error();
                             error.message = 'BOTs Remote Engine is not configured or not in running mode';
                             error.status = 403;
-                            next(error, null);
+                            //next(error, null);
+                            encryptedParam(reqBody, next);
                         }
                     });
 


### PR DESCRIPTION
… Server and not re-query for status.